### PR TITLE
Fix game end check to determine if all ships have sunk

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,8 @@ import {
   initializeBoard,
   initializeEnemyBoard,
   isHit,
-  placeShip
+  placeShip,
+  areAllShipsSunk
 } from './game/board-service';
 import './App.css';
 
@@ -89,7 +90,8 @@ export default class App extends Component {
       currentPosition: undefined,
       currentShipIndex: 0,
       enemyBoard: initializeEnemyBoard(),
-      myBoard: initializeBoard()
+      myBoard: initializeBoard(),
+      gameOver: false
     };
   }
 
@@ -113,18 +115,36 @@ export default class App extends Component {
     }
   };
 
+  checkIfAllShipsSunk = (board) => {
+    return areAllShipsSunk(board.fleet);
+  };
+
   shoot = position => {
+    if (this.state.gameOver) return;
+
     alert(
       `Shoot at ${position}: ${
         isHit(this.state.enemyBoard, position) ? 'Hit!' : 'Miss!'
       }`
     );
+
+    if (this.checkIfAllShipsSunk(this.state.enemyBoard)) {
+      this.setState({ gameOver: true });
+      alert('All enemy ships have sunk! You win!');
+      return;
+    }
+
     const counterAttack = getRandomPosition(8, 8);
     alert(
       `Enemy shoots at ${counterAttack}: ${
         isHit(this.state.myBoard, counterAttack) ? 'Hit!' : 'Miss!'
       }`
     );
+
+    if (this.checkIfAllShipsSunk(this.state.myBoard)) {
+      this.setState({ gameOver: true });
+      alert('All your ships have sunk! You lose!');
+    }
   };
 
   render() {

--- a/src/game/board-service.js
+++ b/src/game/board-service.js
@@ -94,3 +94,7 @@ export function getRandomPosition(columnCount, rowCount) {
   const row = (Math.round(Math.random()) * columnCount).toString();
   return column + row;
 }
+
+export function areAllShipsSunk(fleet) {
+  return fleet.every(ship => ship.positions.length === 0);
+}

--- a/src/game/board-service.spec.js
+++ b/src/game/board-service.spec.js
@@ -3,7 +3,8 @@ import {
   initializeEnemyBoard,
   getRelativePosition,
   isHit,
-  placeShip
+  placeShip,
+  areAllShipsSunk
 } from './board-service';
 
 describe('the board service', () => {
@@ -94,5 +95,18 @@ describe('the board service', () => {
     const enemyBoard = initializeEnemyBoard();
     expect(isHit(enemyBoard, 'B3')).toBe(true);
     expect(isHit(enemyBoard, 'B1')).toBe(false);
+  });
+
+  it('should check if all ships are sunk', () => {
+    const board = initializeBoard();
+    expect(areAllShipsSunk(board.fleet)).toBe(true);
+    placeShip(board, 0, 'A1', 'down');
+    expect(areAllShipsSunk(board.fleet)).toBe(false);
+  });
+
+  it('should not end the game when ships are still afloat', () => {
+    const board = initializeBoard();
+    placeShip(board, 0, 'A1', 'down');
+    expect(areAllShipsSunk(board.fleet)).toBe(false);
   });
 });


### PR DESCRIPTION
Add functionality to check if all ships have sunk and end the game.

* **src/App.jsx**
  - Import `areAllShipsSunk` function.
  - Add `gameOver` state to track if the game is over.
  - Add `checkIfAllShipsSunk` function to check if all ships have sunk.
  - Call `checkIfAllShipsSunk` after each shot to determine if the game is over.
  - Display a message when all ships have sunk and the game is over.

* **src/game/board-service.js**
  - Add `areAllShipsSunk` function to check if all ships in the fleet have sunk.
  - Export the `areAllShipsSunk` function.

* **src/game/board-service.spec.js**
  - Add a test for the new `areAllShipsSunk` function.
  - Add a test that the game does NOT end when ships are still afloat.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/copilot-shorts/BattleJSip?shareId=0c53cfb1-ed93-4322-9de1-5467735d850c).